### PR TITLE
Добавил информацию о nvidia интерфейсе управления питания nvidia.md

### DIFF
--- a/docs/equipment/nvidia.md
+++ b/docs/equipment/nvidia.md
@@ -108,8 +108,24 @@ mcedit /etc/sysconfig/grub2
 ```shell
 su -
 grub-mkconfig -o /boot/grub/grub.cfg
-ln -s /dev/null /etc/udev/rules.d/61-gdm.rules
 ```
+Активируем интерфейсы управления питания nvidia. Помимо предотвращения проблем с сохранением видеопамяти при входе в спящий режим и гибернизации ![(см. источник)](https://download.nvidia.com/XFree86/Linux-x86_64/550.40.07/README/powermanagement.html), активация этих интерфейсов необходима для ![правил](https://gitlab.gnome.org/GNOME/gdm/-/blob/main/data/61-gdm.rules.in#L51) разрешения протокола wayland на GDM.(Чтобы wayland режим был доступен при выборе сессии)
+
+```shell
+su -
+systemctl enable nvidia-suspend.service nvidia-resume.service nvidia-hibernate.service
+```
+В опциях драйверов nvidia указываем о смене способа сохранения видеопамяти.
+
+```shell
+su -
+cat << _EOF_ > /etc/modprobe.d/nvidia_videomemory_allocation.conf
+options nvidia NVreg_PreserveVideoMemoryAllocations=1
+options nvidia NVreg_TemporaryFilePath=/run
+_EOF_
+```
+::: tip
+Для сохранения видеопамяти важно, чтобы файловая система имела поддержку безымянный временных файлов и имела достаточный объём для сохранения видеопамяти. Объём, равный сумме всей видеопамяти + 5% от неё, будет вполне достаточно для её сохранения. 
 
 Перезагружаем операционную систему, выберите в списке сессию Gnome.
 


### PR DESCRIPTION
Добавил информацию для корректного сохранения видеопамяти при входе в спящий режим.

Удалил `ln -s /dev/null /etc/udev/rules.d/61-gdm.rules`, т.к. эта команда не имела описания для чего она нужна и при активации nvidia-suspend.service, nvidia-resume.service, NVreg_PreserveVideoMemoryAllocations и nvidia-drm.modeset=1, правила полностью выполняются и нет необходимости их заглушать. [Правила GDM](https://gitlab.gnome.org/GNOME/gdm/-/blob/main/data/61-gdm.rules.in#L51)

Можно вернуть способ заглушки правил, как альтернативу, т.к. не всегда необходим специальный интерфейс для питания. Бывает и так, что системной памяти достаточно, когда видеопамяти немного, по сравнению с ОЗУ.

Неуверен насчёт моего расположения :::tip 
Мне кажется, он теперь разделяет информацию о nvidia-drm.modeset=1 на две части