### PR TITLE
ошибка-пункт-wiki-grapejuice.md

### DIFF
--- a/docs/main/wiki.md
+++ b/docs/main/wiki.md
@@ -56,7 +56,7 @@ docs:
                 - name: Сartridges
                   link: cartridges
                 - name: Grapejuice
-                - link: grapejuice
+                  link: grapejuice
             - title: Офис
               icon:
                 dark: /document-light.svg


### PR DESCRIPTION
Перед link случайно оставил знак, пункт был, но не кликабельный