### PR TITLE
Добавлено: PageProperties (Детали в комментарии)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -24,6 +24,12 @@ import {
   GitChangelog,
   GitChangelogMarkdownSection 
 } from '@nolebase/vitepress-plugin-git-changelog/vite'
+ 
+/* PagePropierties */
+import { 
+  PageProperties,
+  PagePropertiesMarkdownSection
+} from '@nolebase/vitepress-plugin-page-properties/vite'
 
 import {
   gitRepository,
@@ -58,6 +64,17 @@ export default defineConfig({
           return false
         },
         sections: gitDisplay,
+      }),
+      PageProperties(),
+      PagePropertiesMarkdownSection({
+        excludes: [],
+        exclude: (_, { helpers }): boolean => {
+          for (var page of config.nolebase_exclude){
+            if (helpers.idEndsWith(page))
+              return null
+          }
+          return false
+        },
       }),
     ],
     ssr: {

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -38,6 +38,18 @@ import {
   gitMapContributors
 } from '../../_data/gitlog'
 
+import {
+  NolebasePagePropertiesEditor,
+} from '@nolebase/vitepress-plugin-page-properties/client'
+
+import {
+  pagePropertiesLocales,
+  pagePropertiesMD
+} from './../../_data/page-properties'
+
+import type { Options as NolebasePagePropertiesOptions } from '@nolebase/vitepress-plugin-page-properties/client';
+import { InjectionKey as NolebasePagePropertiesInjection } from '@nolebase/vitepress-plugin-page-properties/client';
+
 
 /* Stylesheets */
 import 'uno.css'
@@ -45,6 +57,7 @@ import './styles/style.css'
 import './styles/custom.css'
 import './viewerjs/dist/viewer.css'
 import '@nolebase/vitepress-plugin-enhanced-readabilities/dist/style.css'
+import '@nolebase/vitepress-plugin-page-properties/client/style.css'
 import "vitepress-markdown-timeline/dist/theme/index.css";
 
 export default {
@@ -55,6 +68,7 @@ export default {
       'nav-bar-content-after': () => h(NolebaseEnhancedReadabilitiesMenu),
       'nav-screen-content-after': () => h(NolebaseEnhancedReadabilitiesScreenMenu),
       'aside-outline-after': () => h(AGWMetaBars),
+      'doc-footer-before': () => h(NolebasePagePropertiesEditor)
     })
   },
 
@@ -74,7 +88,7 @@ export default {
     
     ctx.app.component('AGWGallery', AGWGallery);
     ctx.app.component('AGWCategories', AGWCategories)
-
+    ctx.app.provide(NolebasePagePropertiesInjection, {locales: pagePropertiesLocales, properties:pagePropertiesMD} as NolebasePagePropertiesOptions)
     ctx.app.use(NolebaseGitChangelogPlugin, {locales: gitLocales, mapContributors: gitMapContributors})
 
     enhanceAppWithTabs(ctx.app)

--- a/.vitepress/theme/styles/style.css
+++ b/.vitepress/theme/styles/style.css
@@ -143,3 +143,10 @@
 .bg-\$vp-custom-block-details-bg, .bg-vp-custom-block-details-bg{
   background-color: var(--vp-c-gray-3) !important;
 }
+
+/**
+ * Component: Page Properties
+ * -------------------------------------------------------------------------- */
+ .VPDocFooter[data-v-29ec59c0]{
+  margin-top: 10px !important;
+}

--- a/_data/page-properties.ts
+++ b/_data/page-properties.ts
@@ -1,0 +1,53 @@
+export const pagePropertiesMD = {
+    'ru-RU': [
+        {
+          key: 'tags',
+          type: 'tags',
+          title: 'Теги',
+        },
+        {
+          key: 'progress',
+          type: 'progress',
+          title: 'Прогресс',
+        },
+        {
+          key: 'createdAt',
+          type: 'datetime',
+          title: 'Создано',
+          formatAsFrom: true,
+          dateFnsLocaleName: 'ru',
+        },
+        {
+          key: 'updatedAt',
+          type: 'datetime',
+          title: 'Обновлено',
+          formatAsFrom: true,
+          dateFnsLocaleName: 'ru',
+        },
+        /*
+        {
+          key: 'wordsCount',
+          type: 'dynamic',
+          title: 'Количество слов',
+          options: {
+            type: 'wordsCount',
+          },
+        },
+        {
+          key: 'readingTime',
+          type: 'dynamic',
+          title: 'Время чтения',
+          options: {
+            type: 'readingTime',
+            dateFnsLocaleName: 'ru',
+          },
+        },
+        */
+      ],
+}
+
+export const pagePropertiesLocales = {
+    'ru-RU':{
+        wordsCount: '{{wordsCount}}   слов'
+    }
+}

--- a/docs/equipment/dualshock.md
+++ b/docs/equipment/dualshock.md
@@ -1,3 +1,11 @@
+---
+tags:
+- Устройства/Геймпады
+- DualShock
+createdAt: 02-29-2024
+progress: 70
+---
+
 # Подключение геймпадов семейства DualShock
 
 ## DualShock 3

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@nolebase/vitepress-plugin-page-properties": "^1.25.2",
         "shiki": "^1.2.0",
         "swiper": "^11.0.6",
         "unocss": "^0.58.6",
@@ -12,7 +13,7 @@
       },
       "devDependencies": {
         "@hywax/vitepress-yandex-metrika": "^0.3.3",
-        "@nolebase/vitepress-plugin-enhanced-readabilities": "^1.10.0",
+        "@nolebase/vitepress-plugin-enhanced-readabilities": "^1.25.2",
         "@nolebase/vitepress-plugin-git-changelog": "^1.25.2",
         "@types/markdown-it": "^13.0.5",
         "@types/markdown-it-container": "^2.0.8",
@@ -34,7 +35,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
       "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
-      "dev": true,
       "dependencies": {
         "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
         "@algolia/autocomplete-shared": "1.9.3"
@@ -44,7 +44,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
       "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
-      "dev": true,
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
       },
@@ -56,7 +55,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
       "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
-      "dev": true,
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
       },
@@ -69,7 +67,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
       "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
-      "dev": true,
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
         "algoliasearch": ">= 4.9.1 < 6"
@@ -79,7 +76,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.1.tgz",
       "integrity": "sha512-Sw6IAmOCvvP6QNgY9j+Hv09mvkvEIDKjYW8ow0UDDAxSXy664RBNQk3i/0nt7gvceOJ6jGmOTimaZoY1THmU7g==",
-      "dev": true,
       "dependencies": {
         "@algolia/cache-common": "4.22.1"
       }
@@ -87,14 +83,12 @@
     "node_modules/@algolia/cache-common": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.1.tgz",
-      "integrity": "sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA==",
-      "dev": true
+      "integrity": "sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA=="
     },
     "node_modules/@algolia/cache-in-memory": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.1.tgz",
       "integrity": "sha512-ve+6Ac2LhwpufuWavM/aHjLoNz/Z/sYSgNIXsinGofWOysPilQZPUetqLj8vbvi+DHZZaYSEP9H5SRVXnpsNNw==",
-      "dev": true,
       "dependencies": {
         "@algolia/cache-common": "4.22.1"
       }
@@ -103,7 +97,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.1.tgz",
       "integrity": "sha512-k8m+oegM2zlns/TwZyi4YgCtyToackkOpE+xCaKCYfBfDtdGOaVZCM5YvGPtK+HGaJMIN/DoTL8asbM3NzHonw==",
-      "dev": true,
       "dependencies": {
         "@algolia/client-common": "4.22.1",
         "@algolia/client-search": "4.22.1",
@@ -114,7 +107,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.1.tgz",
       "integrity": "sha512-1ssi9pyxyQNN4a7Ji9R50nSdISIumMFDwKNuwZipB6TkauJ8J7ha/uO60sPJFqQyqvvI+px7RSNRQT3Zrvzieg==",
-      "dev": true,
       "dependencies": {
         "@algolia/client-common": "4.22.1",
         "@algolia/client-search": "4.22.1",
@@ -126,7 +118,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.1.tgz",
       "integrity": "sha512-IvaL5v9mZtm4k4QHbBGDmU3wa/mKokmqNBqPj0K7lcR8ZDKzUorhcGp/u8PkPC/e0zoHSTvRh7TRkGX3Lm7iOQ==",
-      "dev": true,
       "dependencies": {
         "@algolia/requester-common": "4.22.1",
         "@algolia/transporter": "4.22.1"
@@ -136,7 +127,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.1.tgz",
       "integrity": "sha512-sl+/klQJ93+4yaqZ7ezOttMQ/nczly/3GmgZXJ1xmoewP5jmdP/X/nV5U7EHHH3hCUEHeN7X1nsIhGPVt9E1cQ==",
-      "dev": true,
       "dependencies": {
         "@algolia/client-common": "4.22.1",
         "@algolia/requester-common": "4.22.1",
@@ -147,7 +137,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.1.tgz",
       "integrity": "sha512-yb05NA4tNaOgx3+rOxAmFztgMTtGBi97X7PC3jyNeGiwkAjOZc2QrdZBYyIdcDLoI09N0gjtpClcackoTN0gPA==",
-      "dev": true,
       "dependencies": {
         "@algolia/client-common": "4.22.1",
         "@algolia/requester-common": "4.22.1",
@@ -157,14 +146,12 @@
     "node_modules/@algolia/logger-common": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.1.tgz",
-      "integrity": "sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg==",
-      "dev": true
+      "integrity": "sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg=="
     },
     "node_modules/@algolia/logger-console": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.1.tgz",
       "integrity": "sha512-O99rcqpVPKN1RlpgD6H3khUWylU24OXlzkavUAMy6QZd1776QAcauE3oP8CmD43nbaTjBexZj2nGsBH9Tc0FVA==",
-      "dev": true,
       "dependencies": {
         "@algolia/logger-common": "4.22.1"
       }
@@ -173,7 +160,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.1.tgz",
       "integrity": "sha512-dtQGYIg6MteqT1Uay3J/0NDqD+UciHy3QgRbk7bNddOJu+p3hzjTRYESqEnoX/DpEkaNYdRHUKNylsqMpgwaEw==",
-      "dev": true,
       "dependencies": {
         "@algolia/requester-common": "4.22.1"
       }
@@ -181,14 +167,12 @@
     "node_modules/@algolia/requester-common": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.1.tgz",
-      "integrity": "sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg==",
-      "dev": true
+      "integrity": "sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg=="
     },
     "node_modules/@algolia/requester-node-http": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.1.tgz",
       "integrity": "sha512-JfmZ3MVFQkAU+zug8H3s8rZ6h0ahHZL/SpMaSasTCGYR5EEJsCc8SI5UZ6raPN2tjxa5bxS13BRpGSBUens7EA==",
-      "dev": true,
       "dependencies": {
         "@algolia/requester-common": "4.22.1"
       }
@@ -197,7 +181,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.1.tgz",
       "integrity": "sha512-kzWgc2c9IdxMa3YqA6TN0NW5VrKYYW/BELIn7vnLyn+U/RFdZ4lxxt9/8yq3DKV5snvoDzzO4ClyejZRdV3lMQ==",
-      "dev": true,
       "dependencies": {
         "@algolia/cache-common": "4.22.1",
         "@algolia/logger-common": "4.22.1",
@@ -740,14 +723,12 @@
     "node_modules/@docsearch/css": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.0.tgz",
-      "integrity": "sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ==",
-      "dev": true
+      "integrity": "sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ=="
     },
     "node_modules/@docsearch/js": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.6.0.tgz",
       "integrity": "sha512-QujhqINEElrkIfKwyyyTfbsfMAYCkylInLYMRqHy7PHc8xTBQCow73tlo/Kc7oIwBrCLf0P3YhjlOeV4v8hevQ==",
-      "dev": true,
       "dependencies": {
         "@docsearch/react": "3.6.0",
         "preact": "^10.0.0"
@@ -757,7 +738,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.0.tgz",
       "integrity": "sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==",
-      "dev": true,
       "dependencies": {
         "@algolia/autocomplete-core": "1.9.3",
         "@algolia/autocomplete-preset-algolia": "1.9.3",
@@ -1316,9 +1296,9 @@
       }
     },
     "node_modules/@nolebase/vitepress-plugin-enhanced-readabilities": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/@nolebase/vitepress-plugin-enhanced-readabilities/-/vitepress-plugin-enhanced-readabilities-1.24.2.tgz",
-      "integrity": "sha512-V/YgtvHmV2BIin/3Lt+re7CDs6AzEWmeiAE7O8nE6PN5e2f7hkeuDaH3Z6r50exykgyZE6MuQ8//NtxtF5KGjA==",
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@nolebase/vitepress-plugin-enhanced-readabilities/-/vitepress-plugin-enhanced-readabilities-1.25.2.tgz",
+      "integrity": "sha512-B0fSW+oGzPTD8Z4F5RZKdhj33f50Oq7FGn+n+ToZ8uOcGTMIKGrmWLdVFrdrl30MY4guRCmv7o4eVIiKCGfEKQ==",
       "dev": true,
       "peerDependencies": {
         "vitepress": ">=1.0.0-rc.44"
@@ -1337,6 +1317,19 @@
         "ora": "^8.0.1",
         "simple-git": "^3.22.0",
         "uncrypto": "^0.1.3"
+      },
+      "peerDependencies": {
+        "vitepress": ">=1.0.0-rc.44"
+      }
+    },
+    "node_modules/@nolebase/vitepress-plugin-page-properties": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@nolebase/vitepress-plugin-page-properties/-/vitepress-plugin-page-properties-1.25.2.tgz",
+      "integrity": "sha512-VKoX4OLF6aCC0N4rpCDvUw8ZJP9Bkma8i93Z2pZ3jDQAe/IDhJGq9pK0PgadDJaOIXOTf27BreRsPw+Mxr4Jdg==",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "markdown-it": "^13.0.2",
+        "uuid": "^9.0.1"
       },
       "peerDependencies": {
         "vitepress": ">=1.0.0-rc.44"
@@ -1539,7 +1532,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.2.0.tgz",
       "integrity": "sha512-xKn7DtA65DQV4FOfYsrvqM80xOy2xuXnxWWKsZmHv1VII/IOuDUDsWDu3KnpeLH6wqNJWp1GRoNUsHR1aw/VhQ==",
-      "dev": true,
       "dependencies": {
         "shiki": "1.2.0"
       }
@@ -1597,14 +1589,12 @@
     "node_modules/@types/linkify-it": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
-      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
-      "dev": true
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw=="
     },
     "node_modules/@types/markdown-it": {
       "version": "13.0.7",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
       "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
-      "dev": true,
       "dependencies": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
@@ -1622,8 +1612,7 @@
     "node_modules/@types/mdurl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
-      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
-      "dev": true
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA=="
     },
     "node_modules/@types/node": {
       "version": "20.11.30",
@@ -1644,8 +1633,7 @@
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
-      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-      "dev": true
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -1993,7 +1981,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.4.tgz",
       "integrity": "sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==",
-      "dev": true,
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       },
@@ -2006,7 +1993,6 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.21.tgz",
       "integrity": "sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.9",
         "@vue/shared": "3.4.21",
@@ -2019,7 +2005,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -2031,7 +2016,6 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz",
       "integrity": "sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-core": "3.4.21",
         "@vue/shared": "3.4.21"
@@ -2041,7 +2025,6 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz",
       "integrity": "sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.9",
         "@vue/compiler-core": "3.4.21",
@@ -2058,7 +2041,6 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz",
       "integrity": "sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-dom": "3.4.21",
         "@vue/shared": "3.4.21"
@@ -2068,7 +2050,6 @@
       "version": "7.0.20",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.0.20.tgz",
       "integrity": "sha512-DGEIdotTQFll4187YGc/0awcag7UGJu9M6rE1Pxcs8AX/sGm0Ikk7UqQELmqYsyPzTT9s6OZzSPuBc4OatOXKA==",
-      "dev": true,
       "dependencies": {
         "@vue/devtools-kit": "^7.0.20"
       }
@@ -2077,7 +2058,6 @@
       "version": "7.0.20",
       "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.0.20.tgz",
       "integrity": "sha512-FgFuPuqrhQ51rR/sVi52FnGgrxJ3X1bvNra/SkBzPhxJVhfyL5w2YUJZI1FgCvtLAyPSomJNdvlG415ZbJsr6w==",
-      "dev": true,
       "dependencies": {
         "@vue/devtools-shared": "^7.0.20",
         "hookable": "^5.5.3",
@@ -2093,7 +2073,6 @@
       "version": "7.0.20",
       "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.0.20.tgz",
       "integrity": "sha512-E6CiCaYr6ZWOCYJgWodXcPCXxB12vgbUA1X1sG0F1tK5Bo5I35GJuTR8LBJLFHV0VpwLWvyrIi9drT1ZbuJxlg==",
-      "dev": true,
       "dependencies": {
         "rfdc": "^1.3.1"
       }
@@ -2102,7 +2081,6 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.21.tgz",
       "integrity": "sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==",
-      "dev": true,
       "dependencies": {
         "@vue/shared": "3.4.21"
       }
@@ -2111,7 +2089,6 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.21.tgz",
       "integrity": "sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==",
-      "dev": true,
       "dependencies": {
         "@vue/reactivity": "3.4.21",
         "@vue/shared": "3.4.21"
@@ -2121,7 +2098,6 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz",
       "integrity": "sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==",
-      "dev": true,
       "dependencies": {
         "@vue/runtime-core": "3.4.21",
         "@vue/shared": "3.4.21",
@@ -2132,7 +2108,6 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.21.tgz",
       "integrity": "sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.4.21",
         "@vue/shared": "3.4.21"
@@ -2144,14 +2119,12 @@
     "node_modules/@vue/shared": {
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.21.tgz",
-      "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g==",
-      "dev": true
+      "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g=="
     },
     "node_modules/@vueuse/core": {
       "version": "10.9.0",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.9.0.tgz",
       "integrity": "sha512-/1vjTol8SXnx6xewDEKfS0Ra//ncg4Hb0DaZiwKf7drgfMsKFExQ+FnnENcN6efPen+1kIzhLQoGSy0eDUVOMg==",
-      "dev": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
         "@vueuse/metadata": "10.9.0",
@@ -2166,7 +2139,6 @@
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
       "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -2192,7 +2164,6 @@
       "version": "10.9.0",
       "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.9.0.tgz",
       "integrity": "sha512-acK+A01AYdWSvL4BZmCoJAcyHJ6EqhmkQEXbQLwev1MY7NBnS+hcEMx/BzVoR9zKI+UqEPMD9u6PsyAuiTRT4Q==",
-      "dev": true,
       "dependencies": {
         "@vueuse/core": "10.9.0",
         "@vueuse/shared": "10.9.0",
@@ -2258,7 +2229,6 @@
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
       "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -2284,7 +2254,6 @@
       "version": "10.9.0",
       "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.9.0.tgz",
       "integrity": "sha512-iddNbg3yZM0X7qFY2sAotomgdHK7YJ6sKUvQqbvwnf7TmaVPxS4EJydcNsVejNdS8iWCtDk+fYXr7E32nyTnGA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -2293,7 +2262,6 @@
       "version": "10.9.0",
       "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.9.0.tgz",
       "integrity": "sha512-Uud2IWncmAfJvRaFYzv5OHDli+FbOzxiVEQdLCKQKLyhz94PIyFC3CHcH7EDMwIn8NPtD06+PNbC/PiO0LGLtw==",
-      "dev": true,
       "dependencies": {
         "vue-demi": ">=0.14.7"
       },
@@ -2305,7 +2273,6 @@
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
       "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -2342,7 +2309,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.1.tgz",
       "integrity": "sha512-jwydKFQJKIx9kIZ8Jm44SdpigFwRGPESaxZBaHSV0XWN2yBJAOT4mT7ppvlrpA4UGzz92pqFnVKr/kaZXrcreg==",
-      "dev": true,
       "dependencies": {
         "@algolia/cache-browser-local-storage": "4.22.1",
         "@algolia/cache-common": "4.22.1",
@@ -2401,8 +2367,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2633,8 +2598,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/date-fns": {
       "version": "3.6.0",
@@ -2708,7 +2672,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
       "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -2771,6 +2734,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -2813,6 +2788,17 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-glob": {
@@ -2868,7 +2854,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
       "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
-      "dev": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -2943,6 +2928,20 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -2970,8 +2969,7 @@
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-      "dev": true
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -2990,6 +2988,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -3153,6 +3159,26 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -3180,6 +3206,14 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
       "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
@@ -3189,7 +3223,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
       "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-      "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -3285,14 +3318,12 @@
     "node_modules/mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
-      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
-      "dev": true
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
     "node_modules/markdown-it": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
       "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~3.0.1",
@@ -3417,8 +3448,7 @@
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "dev": true
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -3474,14 +3504,12 @@
     "node_modules/minisearch": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
-      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ==",
-      "dev": true
+      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ=="
     },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/mlly": {
       "version": "1.6.1",
@@ -3723,7 +3751,6 @@
       "version": "10.20.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.20.1.tgz",
       "integrity": "sha512-JIFjgFg9B2qnOoGiYMVBtrcFxHqn+dNXbq76bVmcaHYJFYR4lW67AOcXgAYQQTDYXDOg/kTZrKPNCdRgJ2UJmw==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -3823,8 +3850,7 @@
     "node_modules/rfdc": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
-      "dev": true
+      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg=="
     },
     "node_modules/rollup": {
       "version": "4.13.0",
@@ -3883,8 +3909,19 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
       "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
-      "dev": true,
       "peer": true
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -3976,7 +4013,6 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
       "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3984,8 +4020,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -4056,6 +4091,14 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -4098,8 +4141,7 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "dev": true
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -4131,8 +4173,7 @@
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/ufo": {
       "version": "1.5.3",
@@ -4239,6 +4280,18 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/viewerjs": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/viewerjs/-/viewerjs-1.11.6.tgz",
@@ -4303,7 +4356,6 @@
       "version": "1.0.0-rc.45",
       "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.45.tgz",
       "integrity": "sha512-/OiYsu5UKpQKA2c0BAZkfyywjfauDjvXyv6Mo4Ra57m5n4Bxg1HgUGoth1CLH2vwUbR/BHvDA9zOM0RDvgeSVQ==",
-      "dev": true,
       "dependencies": {
         "@docsearch/css": "^3.5.2",
         "@docsearch/js": "^3.5.2",
@@ -4369,7 +4421,6 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.21.tgz",
       "integrity": "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-dom": "3.4.21",
         "@vue/compiler-sfc": "3.4.21",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "@hywax/vitepress-yandex-metrika": "^0.3.3",
-    "@nolebase/vitepress-plugin-enhanced-readabilities": "^1.10.0",
+    "@nolebase/vitepress-plugin-enhanced-readabilities": "^1.25.2",
     "@nolebase/vitepress-plugin-git-changelog": "^1.25.2",
     "@types/markdown-it": "^13.0.5",
     "@types/markdown-it-container": "^2.0.8",
@@ -19,6 +19,7 @@
     "vitepress-plugin-tabs": "^0.5.0"
   },
   "dependencies": {
+    "@nolebase/vitepress-plugin-page-properties": "^1.25.2",
     "shiki": "^1.2.0",
     "swiper": "^11.0.6",
     "unocss": "^0.58.6",


### PR DESCRIPTION
**Дополнение:**
Добавлен и настроен пакет `@nolebase/vitepress-plugins-page-propierties` по issue https://github.com/OlegShchavelev/ALTRegularGnomeWiki/issues/129 , но не решены вопросы поводу индексации - до тех пор невозможно использовать поля "Количество слов" и "Время чтения". Их плагин не может проиндексировать из за специфики наших url.

Когда вопрос будет решен - можно будет раскомментировать поля в `_data/page-properties`

**Формат заполнения:**
```md
---
tags:
- Тег1
- Тег2
progress: число
createdAt: месяц-день-год
updatedAt: месяц-день-год
---
```
